### PR TITLE
I don't think the repairs ever worked for negative murmur3 tokens, becau...

### DIFF
--- a/range_repair.py
+++ b/range_repair.py
@@ -25,7 +25,7 @@ import platform
 class Token_Container:
     RANGE_MIN = -(2**63)
     RANGE_MAX = (2**63)-1
-    FORMAT_TEMPLATE = "{0:020d}"
+    FORMAT_TEMPLATE = "{0:+021d}"
     def __init__(self, options):
         '''Initialize the Token Container by getting the host and ring tokens and
         then confirming the values used for formatting and range

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -94,3 +94,9 @@ class range_tests(unittest.TestCase):
             resultset.append(x[0])
         self.assertEquals(len(resultset), 6)
         return
+    def test_Murmur3_format_length(self):
+        t = range_repair.Token_Container(self.f)
+        self.assertEquals(21, len(t.format(0)))
+        self.assertEquals(21, len(t.format(100)))
+        self.assertEquals(21, len(t.format(-100)))
+


### PR DESCRIPTION
...se

the old format string was only ever producing a 20-byte string _including_
the minus sign.  The new format string always prints the sign, and that
work for 1.2.x.  Someone testing on 2.x would be good.
