### PR TITLE
Remove redundant local flag

### DIFF
--- a/range_repair.py
+++ b/range_repair.py
@@ -221,7 +221,7 @@ def repair_range(options, start, end, step, nodeposition):
     else:
         cmd.extend(["-pr"])
         
-    cmd.extend([options.local, options.par, options.inc, options.snapshot,
+    cmd.extend([options.par, options.inc, options.snapshot,
                  "-st", start, "-et", end])
 
     if not options.dry_run:


### PR DESCRIPTION
This should've been part of commit 5dd5f20 ("Fix - use local or pr flag (cannot use both)").