### PR TITLE
Fix regex to catch the DC, broken for C* 2.0 

### DIFF
--- a/src/range_repair.py
+++ b/src/range_repair.py
@@ -55,7 +55,7 @@ class Token_Container:
         # This is a really well-specified value.  If the format of the
         # output of 'nodetool gossipinfo' changes, this will have to be
         # revisited.
-        search_regex = "DC:\d:{datacenter}".format(datacenter=self.options.datacenter)
+        search_regex = "DC(?:\d)?:{datacenter}".format(datacenter=self.options.datacenter)
         for paragraph in stdout.split("/"):
             if not re.search(search_regex, paragraph):
                 continue
@@ -222,7 +222,7 @@ def repair_range(options, start, end, step, nodeposition):
         cmd.extend([options.local])
     else:
         cmd.extend(["-pr"])
-        
+
     cmd.extend([options.par, options.inc, options.snapshot,
                  "-st", start, "-et", end])
 


### PR DESCRIPTION
* Not working on 2.0 with a specified datacenter since https://github.com/BrianGallew/cassandra_range_repair/commit/277f0f10207c10b2b42797fda104f87bdec7d362
* Added an optional capture group, this should not break anything and fixes the bug