### PR TITLE
Adjusting regex to account for 2.1/2.0

### DIFF
--- a/src/range_repair.py
+++ b/src/range_repair.py
@@ -56,7 +56,7 @@ class Token_Container:
         # This is a really well-specified value.  If the format of the
         # output of 'nodetool gossipinfo' changes, this will have to be
         # revisited.
-        search_regex = "DC(?:\d)?:{datacenter}".format(datacenter=self.options.datacenter)
+        search_regex = "DC(?::\d)?:{datacenter}".format(datacenter=self.options.datacenter)
         for paragraph in stdout.split("/"):
             if not re.search(search_regex, paragraph):
                 continue


### PR DESCRIPTION
I was having issues running this in a multi-datacenter environment using cassandra 2.1.13.  I think the regex pattern was missing a colon, since '?:' specifies a [non-capturing group](https://docs.python.org/2/howto/regex.html#non-capturing-and-named-groups) but the pattern misses the fact that there is a colon in the output of nodetool gossipinfo:

> /172.16.12.41
>   generation:1464713236
>   heartbeat:333792
>   STATUS:22:NORMAL,-1072269324546935465
>   LOAD:333755:299904.0
>   SCHEMA:10:edc27960-bdfe-350e-a034-e18d61c3a966
>   DC:6:datacenter1
>   RACK:8:rack1
>   RELEASE_VERSION:4:2.1.13
>   RPC_ADDRESS:3:172.16.12.41
>   SEVERITY:333791:0.0
>   NET_VERSION:1:8
>   HOST_ID:2:e1900814-2562-4ad7-bff0-985b9b9c3eac
>   TOKENS:21:<hidden>

[Original regex](http://pythex.org/?regex=DC(%3F%3A%5Cd)%3F%3Adatacenter1&test_string=DC%3Adatacenter1%0ADC%3A8%3Adatacenter1%0ADC%3A3%3Ablah%0ADC%3A2%3Adatacenter1%0ADCdatacenter1&ignorecase=0&multiline=1&dotall=0&verbose=0)
[New regex](http://pythex.org/?regex=DC(%3F%3A%3A%5Cd)%3F%3Adatacenter1&test_string=DC%3Adatacenter1%0ADC%3A8%3Adatacenter1%0ADC%3A3%3Ablah%0ADC%3A2%3Adatacenter1&ignorecase=0&multiline=0&dotall=0&verbose=0)

akonkol@cass01dv2:~/cassandra_range_repair/src$ ./range_repair.py --keyspace=casshub --verbose --debug --workers=1 --datacenter=datacenter1 --logfile=pyrepair
Traceback (most recent call last):
  File "./range_repair.py", line 401, in <module>
    main()
  File "./range_repair.py", line 397, in main
    repair(options)
  File "./range_repair.py", line 278, in repair
    tokens = Token_Container(options)
  File "./range_repair.py", line 38, in __init__
    self.check_for_MD5_tokens()
  File "./range_repair.py", line 75, in check_for_MD5_tokens
    if not self.ring_tokens[0] < 0:
IndexError: list index out of range

2016-06-01 23:08:29,525 - DEBUG - Determining local ring members
2016-06-01 23:08:29,525 - DEBUG - run_command: nodetool -h cass01dv2 gossipinfo
2016-06-01 23:08:30,754 - INFO - Local nodes:
2016-06-01 23:08:30,755 - DEBUG - run_command: nodetool -h cass01dv2 info -T
2016-06-01 23:08:32,093 - DEBUG - 32 host tokens found
2016-06-01 23:08:32,093 - INFO - running nodetool ring, this will take a little bit of time
2016-06-01 23:08:32,094 - DEBUG - run_command: nodetool -h cass01dv2 ring
2016-06-01 23:08:33,392 - DEBUG - ring tokens found, creating ring token list...
2016-06-01 23:08:33,393 - DEBUG - Discarding:
--cut--
016-06-01 23:08:33,399 - DEBUG - Discarding:
2016-06-01 23:08:33,399 - INFO - Found 0 tokens