### PR TITLE
git-ignore some Python related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 logfile.count
 *.pyc
 *~
+/.eggs
+/build
+/cassandra_range_repair.egg-info


### PR DESCRIPTION
They are created when executing

    make clean
    make build
    make test
    make debian

described in the README.