### PR TITLE
Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "nightly" # currently points to 3.6-dev
+# command to install dependencies
+install: "pip install pbr"
+# command to run tests
+script:
+  - make clean
+  - make build
+  - make test
+  - make debian

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.5-dev" # 3.5 development branch
-  - "nightly" # currently points to 3.6-dev
 # command to install dependencies
 install: "pip install pbr"
 # command to run tests

--- a/src/range_repair.py
+++ b/src/range_repair.py
@@ -238,7 +238,7 @@ def run_command(*command):
     :param command: the command to be run and all of the arguments
     :returns: success_boolean, command_string, stdout, stderr
     """
-    cmd = " ".join(command)
+    cmd = " ".join(map(str, command))
     logging.debug("run_command: " + cmd)
     proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = proc.communicate()
@@ -375,7 +375,7 @@ def main():
     parser.add_option("-H", "--host", dest="host", default=platform.node(),
                       metavar="HOST", help="Hostname to repair [default: %default]")
 
-    parser.add_option("-P", "--port", dest="port", default=7199,
+    parser.add_option("-P", "--port", dest="port", default=7199, type="int",
                       metavar="PORT", help="JMX port to use for nodetool commands [default: %default]")
 
     parser.add_option("-s", "--steps", dest="steps", type="int", default=100,


### PR DESCRIPTION
The execution steps are taken from the README file.

This fixes #36.

@BrianGallew Before merging this, should go to https://travis-ci.org and enable Travis CI for this repository.