### PR TITLE
Updating nodetool gossipinfo regex for multiple DC

### DIFF
--- a/src/range_repair.py
+++ b/src/range_repair.py
@@ -106,7 +106,7 @@ class TokenContainer:
         # This is a really well-specified value.  If the format of the
         # output of 'nodetool gossipinfo' changes, this will have to be
         # revisited.
-        search_regex = "DC(?::\d)?:{datacenter}".format(datacenter=self.options.datacenter)
+        search_regex = "DC(?::\d+)?:{datacenter}".format(datacenter=self.options.datacenter)
         for paragraph in stdout.split("/"):
             if not re.search(search_regex, paragraph):
                 continue


### PR DESCRIPTION
We found that in our deployment that `nodetool gossipinfo` returns DC info formated 'DC:{digit}{digit}:{DC Name}'.  The current regex accounts for a single digit.  We updated the regex with '/d+' to account for the multiple digits.

Example:
nodetool gossipinfo | grep DC
  DC:48:AS
  DC:51:WC
  DC:51:WC
  DC:49:WC
  DC:49:AS
  DC:49:AS
  DC:49:WC
  DC:49:AS
  DC:49:WC
  DC:48:AS
  DC:49:WC
  DC:48:AS
  DC:48:AS
  DC:49:WC
  DC:48:AS
  DC:51:WC
  DC:48:AS
  DC:51:AS
  DC:46:AS
  DC:51:AS
  DC:48:AS
  DC:48:AS
  DC:51:AS
  DC:49:AS
  DC:51:AS
