### PR TITLE
Make it Python3 compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ build: clean
 
 test:
 	python setup.py test
+	python3 setup.py test
 	rm -f logfile.count
 
 release: clean

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ DEBUG      2014-05-09 17:33:54,904    repair_keyspace                 182 : SUCC
 ```
 
 ### Dependencies
--   Python 2.6
+-   Python 2.7+
+-   six
 -   Cassandra ```nodetool``` must exist in the ```PATH```
 
 ## How To Test/Contribute

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mock
 pbr
+six

--- a/src/range_repair.py
+++ b/src/range_repair.py
@@ -66,7 +66,7 @@ class ExponentialBackoffRetryer:
                                  else min(next_sleep, self.config.max_sleep))
                     next_sleep *= self.config.sleep_factor
                 else:
-                    logging.warn("Giving up execution. Failed too many times.")
+                    logging.warning("Giving up execution. Failed too many times.")
 
         return result
 

--- a/src/range_repair.py
+++ b/src/range_repair.py
@@ -6,6 +6,8 @@ See the tests subdirectory for example code.
 
 Source: https://github.com/BrianGallew/cassandra_range_repair
 """
+from __future__ import print_function
+
 from optparse import OptionParser, OptionGroup
 
 import logging
@@ -17,7 +19,9 @@ import platform
 import re
 import collections
 import time
+import six
 
+longish = six.integer_types[-1]
 
 ExponentialBackoffRetryerConfig = collections.namedtuple(
     'ExponentialBackoffRetryerConfig', (
@@ -30,6 +34,7 @@ ExponentialBackoffRetryerConfig = collections.namedtuple(
 
 
 class ExponentialBackoffRetryer:
+
     def __init__(self, config, success_checker, executor, sleeper=lambda x: time.sleep(x)):
         """Constructur.
 
@@ -67,6 +72,7 @@ class ExponentialBackoffRetryer:
 
 
 class TokenContainer:
+    'Place to keep tokens'
     RANGE_MIN = -(2**63)
     RANGE_MAX = (2**63)-1
     FORMAT_TEMPLATE = "{0:+021d}"
@@ -151,7 +157,7 @@ class TokenContainer:
             if self.options.datacenter and not segments[0] in self.local_nodes:
                 logging.debug("Discarding node/token %s/%s", segments[0], segments[-1])
                 continue
-            self.ring_tokens.append(long(segments[-1]))
+            self.ring_tokens.append(longish(segments[-1]))
             logging.debug(str(self.ring_tokens))
         self.ring_tokens.sort()
         logging.info("Found {0} tokens".format(len(self.ring_tokens)))
@@ -171,12 +177,11 @@ class TokenContainer:
         for line in stdout.split("\n"):
             if not line.startswith("Token"): continue
             parts = line.split()
-            self.host_tokens.append(long(parts[-1]))
+            self.host_tokens.append(longish(parts[-1]))
         self.host_tokens.sort()
         self.host_token_count = len(self.host_tokens)
         logging.debug("%d host tokens found", self.host_token_count)
         return
-
 
     def format(self, value):
         '''Return the correctly zero-padded string for the token.
@@ -209,7 +214,7 @@ class TokenContainer:
         # This first case works for all but the highest-valued token.
         if stop > start:
             if start+steps < stop+1:
-                step_increment = ((stop - start) / steps)
+                step_increment = ((stop - start) // steps)
                 # We would have an extra, tiny step in the event the range
                 # is not evenly divisible by the number of steps.  This may
                 # give us one larger step at the end.
@@ -220,7 +225,7 @@ class TokenContainer:
         else:                     # This is the wrap-around case
             distance = (self.RANGE_MAX - start) + (stop - self.RANGE_MIN)
             if distance > steps-1:
-                step_increment = distance / steps
+                step_increment = distance // steps
                 # Can't use xrange here because the numbers are too large!
                 step_list = [self.format(x) for x in range(start, self.RANGE_MAX, step_increment)]
                 step_list.extend([self.format(x) for x in range(self.RANGE_MIN, stop, step_increment)])
@@ -243,7 +248,8 @@ def run_command(*command):
     """
     cmd = " ".join(map(str, command))
     logging.debug("run_command: " + cmd)
-    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, universal_newlines=True)
     stdout, stderr = proc.communicate()
     return proc.returncode == 0, cmd, stdout, stderr
 
@@ -283,7 +289,7 @@ def repair_range(options, start, end, step, nodeposition):
         retryer = ExponentialBackoffRetryer(retry_options, lambda x: x[0], run_command)
         success, cmd, _, stderr = retryer(*cmd)
     else:
-        print "{step:04d}/{nodeposition}".format(nodeposition=nodeposition, step=step), " ".join([str(x) for x in cmd])
+        print("{step:04d}/{nodeposition}".format(nodeposition=nodeposition, step=step), " ".join([str(x) for x in cmd]))
         success = True
 
     if not success:

--- a/tests/test_execution_counts.py
+++ b/tests/test_execution_counts.py
@@ -15,7 +15,7 @@ class execution_count_tests(unittest.TestCase):
         results = open('logfile.count').readlines()
         # So 40 is the magic number because:
         # 10 tokens * 4 steps
-        self.assertEquals(len(results), 40)
+        self.assertEqual(len(results), 40)
         return
 
     test_ten_commands.slow=1

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -46,7 +46,7 @@ class range_tests(unittest.TestCase):
         t = range_repair.TokenContainer(self.f)
         for x in t.sub_range_generator(0, 3000, steps=5):
             resultset.append(x[0])
-        self.assertEquals(resultset, [t.format(0), t.format(600), t.format(1200), t.format(1800), t.format(2400)])
+        self.assertEqual(resultset, [t.format(0), t.format(600), t.format(1200), t.format(1800), t.format(2400)])
         return
 
     def test_Murmur3_range_end_zero(self):
@@ -54,7 +54,7 @@ class range_tests(unittest.TestCase):
         t = range_repair.TokenContainer(self.f)
         for x in t.sub_range_generator(-3000, 0, steps=5):
             resultset.append(x[0])
-        self.assertEquals(resultset, [t.format(-3000), t.format(-2400), t.format(-1800), t.format(-1200), t.format(-600)])
+        self.assertEqual(resultset, [t.format(-3000), t.format(-2400), t.format(-1800), t.format(-1200), t.format(-600)])
         return
 
     def test_Murmur3_range_wrap(self):
@@ -63,7 +63,7 @@ class range_tests(unittest.TestCase):
         endpoint = (2**63)-30
         for x in t.sub_range_generator(endpoint, -endpoint, steps=6):
             resultset.append(x[0])
-        self.assertEquals(len(resultset), 7)
+        self.assertEqual(len(resultset), 7)
         return
         
     def test_Random_range_start_zero(self):
@@ -73,7 +73,7 @@ class range_tests(unittest.TestCase):
         t.check_for_MD5_tokens()
         for x in t.sub_range_generator(0, 3000, steps=5):
             resultset.append(x[0])
-        self.assertEquals(resultset, [t.format(0), t.format(600), t.format(1200), t.format(1800), t.format(2400)])
+        self.assertEqual(resultset, [t.format(0), t.format(600), t.format(1200), t.format(1800), t.format(2400)])
         return
 
     def test_Random_range_end_zero(self):
@@ -83,7 +83,7 @@ class range_tests(unittest.TestCase):
         t.check_for_MD5_tokens()
         for x in t.sub_range_generator(-3000, 0, steps=5):
             resultset.append(x[0])
-        self.assertEquals(resultset, [t.format(-3000), t.format(-2400), t.format(-1800), t.format(-1200), t.format(-600)])
+        self.assertEqual(resultset, [t.format(-3000), t.format(-2400), t.format(-1800), t.format(-1200), t.format(-600)])
         return
 
     def test_Random_range_wrap(self):
@@ -94,11 +94,11 @@ class range_tests(unittest.TestCase):
         t.check_for_MD5_tokens()
         for x in t.sub_range_generator(endpoint, -endpoint, steps=6):
             resultset.append(x[0])
-        self.assertEquals(len(resultset), 6)
+        self.assertEqual(len(resultset), 6)
         return
     def test_Murmur3_format_length(self):
         t = range_repair.TokenContainer(self.f)
-        self.assertEquals(21, len(t.format(0)))
-        self.assertEquals(21, len(t.format(100)))
-        self.assertEquals(21, len(t.format(-100)))
+        self.assertEqual(21, len(t.format(0)))
+        self.assertEqual(21, len(t.format(100)))
+        self.assertEqual(21, len(t.format(-100)))
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -36,34 +36,34 @@ def build_fake_retryer(nfails, maxtries, maxsleep=10):
 class RetryTests(unittest.TestCase):
     def test_first_execution_success(self):
         retryer, sleeps = build_fake_retryer(0, 5)
-        self.assertEquals(retryer(), True)
-        self.assertEquals(sleeps, [])
+        self.assertEqual(retryer(), True)
+        self.assertEqual(sleeps, [])
 
     def test_seconds_execution_success(self):
         retryer, sleeps = build_fake_retryer(1, 5)
-        self.assertEquals(retryer(), True)
-        self.assertEquals(sleeps, [1])
+        self.assertEqual(retryer(), True)
+        self.assertEqual(sleeps, [1])
 
     def test_third_execution_success(self):
         retryer, sleeps = build_fake_retryer(2, 5)
-        self.assertEquals(retryer(), True)
-        self.assertEquals(sleeps, [1, 2])
+        self.assertEqual(retryer(), True)
+        self.assertEqual(sleeps, [1, 2])
 
     def test_too_many_retries(self):
         retryer, sleeps = build_fake_retryer(10, 5)
-        self.assertEquals(retryer(), False)
-        self.assertEquals(sleeps, [1, 2, 4, 8])
+        self.assertEqual(retryer(), False)
+        self.assertEqual(sleeps, [1, 2, 4, 8])
 
     def test_max_sleep(self):
         retryer, sleeps = build_fake_retryer(10, 7)
-        self.assertEquals(retryer(), False)
-        self.assertEquals(sleeps, [1, 2, 4, 8, 10, 10])
+        self.assertEqual(retryer(), False)
+        self.assertEqual(sleeps, [1, 2, 4, 8, 10, 10])
 
     def test_disabling_max_sleep(self):
         retryer, sleeps = build_fake_retryer(10, 7, 0)
-        self.assertEquals(retryer(), False)
-        self.assertEquals(sleeps, [1, 2, 4, 8, 16, 32])
+        self.assertEqual(retryer(), False)
+        self.assertEqual(sleeps, [1, 2, 4, 8, 16, 32])
 
         retryer, sleeps = build_fake_retryer(10, 7, -1)
-        self.assertEquals(retryer(), False)
-        self.assertEquals(sleeps, [1, 2, 4, 8, 16, 32])
+        self.assertEqual(retryer(), False)
+        self.assertEqual(sleeps, [1, 2, 4, 8, 16, 32])


### PR DESCRIPTION
Per #45,  add python3 compatibility.  This formalizes the "doesn't work with Python 2.6-" state.