### PR TITLE
Fix travis build requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
 # command to install dependencies
-install: "pip install pbr"
+install: "pip install pbr six"
 # command to run tests
 script:
   - make clean


### PR DESCRIPTION
Per #45,  add python3 compatibility.  This formalizes the "doesn't work with Python 2.6-" state.